### PR TITLE
Split-up core into Router and RouterPayable

### DIFF
--- a/src/core/Router.sol
+++ b/src/core/Router.sol
@@ -8,13 +8,11 @@ import "../eip/ERC165.sol";
 
 abstract contract Router is IRouter, ERC165 {
 
-    fallback() external payable virtual {
+    fallback() external virtual {
     /// @dev delegate calls the appropriate implementation smart contract for a given function.
         address implementation = getImplementationForFunction(msg.sig);
         _delegate(implementation);
     }
-
-    receive() external payable virtual {}
 
     /// @dev See {IERC165-supportsInterface}.
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {

--- a/src/core/RouterNoReceive.sol
+++ b/src/core/RouterNoReceive.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// @author: thirdweb (https://github.com/thirdweb-dev/dynamic-contracts)
+
+pragma solidity ^0.8.0;
+
+import "../interface/IRouter.sol";
+import "../eip/ERC165.sol";
+
+abstract contract RouterNoReceive is IRouter, ERC165 {
+
+    fallback() external payable virtual {
+    /// @dev delegate calls the appropriate implementation smart contract for a given function.
+        address implementation = getImplementationForFunction(msg.sig);
+        _delegate(implementation);
+    }
+
+    /// @dev See {IERC165-supportsInterface}.
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IRouter).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /// @dev delegateCalls an `implementation` smart contract.
+    function _delegate(address implementation) internal virtual {
+        assembly {
+            // Copy msg.data. We take full control of memory in this inline assembly
+            // block because it will not return to Solidity code. We overwrite the
+            // Solidity scratch pad at memory position 0.
+            calldatacopy(0, 0, calldatasize())
+
+            // Call the implementation.
+            // out and outsize are 0 because we don't know the size yet.
+            let result := delegatecall(gas(), implementation, 0, calldatasize(), 0, 0)
+
+            // Copy the returned data.
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            // delegatecall returns 0 on error.
+            case 0 {
+                revert(0, returndatasize())
+            }
+            default {
+                return(0, returndatasize())
+            }
+        }
+    }
+
+    /// @dev Unimplemented. Returns the implementation contract address for a given function signature.
+    function getImplementationForFunction(bytes4 _functionSelector) public view virtual returns (address);
+}

--- a/src/core/RouterPayable.sol
+++ b/src/core/RouterPayable.sol
@@ -3,10 +3,10 @@
 
 pragma solidity ^0.8.0;
 
-import "../interface/IRouter.sol";
+import "../interface/IRouterPayable.sol";
 import "../eip/ERC165.sol";
 
-abstract contract RouterNoReceive is IRouter, ERC165 {
+abstract contract RouterPayable is IRouterPayable, ERC165 {
 
     fallback() external payable virtual {
     /// @dev delegate calls the appropriate implementation smart contract for a given function.
@@ -14,9 +14,11 @@ abstract contract RouterNoReceive is IRouter, ERC165 {
         _delegate(implementation);
     }
 
+    receive() external payable virtual {}
+
     /// @dev See {IERC165-supportsInterface}.
     function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
-        return interfaceId == type(IRouter).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IRouterPayable).interfaceId || super.supportsInterface(interfaceId);
     }
 
     /// @dev delegateCalls an `implementation` smart contract.

--- a/src/interface/IRouterPayable.sol
+++ b/src/interface/IRouterPayable.sol
@@ -3,7 +3,9 @@
 
 pragma solidity ^0.8.0;
 
-interface IRouter {
-    fallback() external;
+interface IRouterPayable {
+    fallback() external payable;
+    receive() external payable;
+
     function getImplementationForFunction(bytes4 _functionSelector) external view returns (address);
 }

--- a/src/presets/BaseRouter.sol
+++ b/src/presets/BaseRouter.sol
@@ -59,23 +59,21 @@ abstract contract BaseRouter is IBaseRouter, Router, ExtensionState {
      *          given precedence over default extensions in DefaultExtensionSet.
      */
     function getAllExtensions() external view returns (Extension[] memory allExtensions) {
-        ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-        string[] memory names = data.extensionNames.values();
+        string[] memory names = _extensionStateStorage().extensionNames.values();
         uint256 namesLen = names.length;
 
         allExtensions = new Extension[](namesLen);
         uint256 idx = 0;
 
         for (uint256 i = 0; i < namesLen; i += 1) {
-            allExtensions[i] = data.extensions[names[i]];
+            allExtensions[i] = _extensionStateStorage().extensions[names[i]];
             idx += 1;
         }
     }
 
     /// @dev Returns the extension metadata and functions for a given extension.
     function getExtension(string memory _extensionName) public view returns (Extension memory) {
-        ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-        return data.extensions[_extensionName];
+        return _extensionStateStorage().extensions[_extensionName];
     }
 
     /// @dev Returns the extension's implementation smart contract address.
@@ -90,8 +88,7 @@ abstract contract BaseRouter is IBaseRouter, Router, ExtensionState {
 
     /// @dev Returns the extension metadata for a given function.
     function getExtensionForFunction(bytes4 _functionSelector) public view returns (ExtensionMetadata memory) {
-        ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-        return data.extensionMetadata[_functionSelector];
+        return _extensionStateStorage().extensionMetadata[_functionSelector];
     }
 
     /// @dev Returns the extension implementation address stored in router, for the given function.

--- a/src/presets/BaseRouterWithDefaults.sol
+++ b/src/presets/BaseRouterWithDefaults.sol
@@ -87,13 +87,12 @@ abstract contract BaseRouterWithDefaults is IBaseRouter, Router, ExtensionState 
         Extension[] memory defaultExtensions = IDefaultExtensionSet(defaultExtensionSet).getAllExtensions();
         uint256 defaultExtensionsLen = defaultExtensions.length;
 
-        ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-        string[] memory names = data.extensionNames.values();
+        string[] memory names = _extensionStateStorage().extensionNames.values();
         uint256 namesLen = names.length;
 
         uint256 overrides = 0;
         for (uint256 i = 0; i < defaultExtensionsLen; i += 1) {
-            if (data.extensionNames.contains(defaultExtensions[i].metadata.name)) {
+            if (_extensionStateStorage().extensionNames.contains(defaultExtensions[i].metadata.name)) {
                 overrides += 1;
             }
         }
@@ -105,24 +104,23 @@ abstract contract BaseRouterWithDefaults is IBaseRouter, Router, ExtensionState 
 
         for (uint256 i = 0; i < defaultExtensionsLen; i += 1) {
             string memory name = defaultExtensions[i].metadata.name;
-            if (!data.extensionNames.contains(name)) {
+            if (!_extensionStateStorage().extensionNames.contains(name)) {
                 allExtensions[idx] = defaultExtensions[i];
                 idx += 1;
             }
         }
 
         for (uint256 i = 0; i < namesLen; i += 1) {
-            allExtensions[idx] = data.extensions[names[i]];
+            allExtensions[idx] = _extensionStateStorage().extensions[names[i]];
             idx += 1;
         }
     }
 
     /// @dev Returns the extension metadata and functions for a given extension.
     function getExtension(string memory _extensionName) public view returns (Extension memory) {
-        ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-        bool isLocalExtension = data.extensionNames.contains(_extensionName);
+        bool isLocalExtension = _extensionStateStorage().extensionNames.contains(_extensionName);
 
-        return isLocalExtension ? data.extensions[_extensionName] : IDefaultExtensionSet(defaultExtensionSet).getExtension(_extensionName);
+        return isLocalExtension ? _extensionStateStorage().extensions[_extensionName] : IDefaultExtensionSet(defaultExtensionSet).getExtension(_extensionName);
     }
 
     /// @dev Returns the extension's implementation smart contract address.
@@ -137,8 +135,7 @@ abstract contract BaseRouterWithDefaults is IBaseRouter, Router, ExtensionState 
 
     /// @dev Returns the extension metadata for a given function.
     function getExtensionForFunction(bytes4 _functionSelector) public view returns (ExtensionMetadata memory) {
-        ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-        ExtensionMetadata memory metadata = data.extensionMetadata[_functionSelector];
+        ExtensionMetadata memory metadata = _extensionStateStorage().extensionMetadata[_functionSelector];
 
         bool isLocalExtension = metadata.implementation != address(0);
 

--- a/src/presets/BaseRouterWithDefaults.sol
+++ b/src/presets/BaseRouterWithDefaults.sol
@@ -11,10 +11,35 @@ import "../core/Router.sol";
 
 // Utils
 import "./utils/StringSet.sol";
+import "./utils/DefaultExtensionSet.sol";
 import "./utils/ExtensionState.sol";
 
-abstract contract BaseRouter is IBaseRouter, Router, ExtensionState {
+abstract contract BaseRouterWithDefaults is IBaseRouter, Router, ExtensionState {
     using StringSet for StringSet.Set;
+
+    /*///////////////////////////////////////////////////////////////
+                            State variables
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice The DefaultExtensionSet that stores default extensions of the router.
+    address public immutable defaultExtensionSet;
+
+    /*///////////////////////////////////////////////////////////////
+                                Constructor
+    //////////////////////////////////////////////////////////////*/
+
+    constructor(Extension[] memory _extensions) {
+
+        DefaultExtensionSet map = new DefaultExtensionSet();
+        defaultExtensionSet = address(map);
+
+        uint256 len = _extensions.length;
+
+        for (uint256 i = 0; i < len; i += 1) {
+            require(_canSetExtension(_extensions[i]), "BaseRouter: not authorized.");
+            map.setExtension(_extensions[i]);
+        }
+    }
 
     /*///////////////////////////////////////////////////////////////
                             ERC 165 logic
@@ -59,15 +84,35 @@ abstract contract BaseRouter is IBaseRouter, Router, ExtensionState {
      *          given precedence over default extensions in DefaultExtensionSet.
      */
     function getAllExtensions() external view returns (Extension[] memory allExtensions) {
+        Extension[] memory defaultExtensions = IDefaultExtensionSet(defaultExtensionSet).getAllExtensions();
+        uint256 defaultExtensionsLen = defaultExtensions.length;
+
         ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
         string[] memory names = data.extensionNames.values();
         uint256 namesLen = names.length;
 
-        allExtensions = new Extension[](namesLen);
+        uint256 overrides = 0;
+        for (uint256 i = 0; i < defaultExtensionsLen; i += 1) {
+            if (data.extensionNames.contains(defaultExtensions[i].metadata.name)) {
+                overrides += 1;
+            }
+        }
+
+        uint256 total = (namesLen + defaultExtensionsLen) - overrides;
+
+        allExtensions = new Extension[](total);
         uint256 idx = 0;
 
+        for (uint256 i = 0; i < defaultExtensionsLen; i += 1) {
+            string memory name = defaultExtensions[i].metadata.name;
+            if (!data.extensionNames.contains(name)) {
+                allExtensions[idx] = defaultExtensions[i];
+                idx += 1;
+            }
+        }
+
         for (uint256 i = 0; i < namesLen; i += 1) {
-            allExtensions[i] = data.extensions[names[i]];
+            allExtensions[idx] = data.extensions[names[i]];
             idx += 1;
         }
     }
@@ -75,7 +120,9 @@ abstract contract BaseRouter is IBaseRouter, Router, ExtensionState {
     /// @dev Returns the extension metadata and functions for a given extension.
     function getExtension(string memory _extensionName) public view returns (Extension memory) {
         ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-        return data.extensions[_extensionName];
+        bool isLocalExtension = data.extensionNames.contains(_extensionName);
+
+        return isLocalExtension ? data.extensions[_extensionName] : IDefaultExtensionSet(defaultExtensionSet).getExtension(_extensionName);
     }
 
     /// @dev Returns the extension's implementation smart contract address.
@@ -91,7 +138,11 @@ abstract contract BaseRouter is IBaseRouter, Router, ExtensionState {
     /// @dev Returns the extension metadata for a given function.
     function getExtensionForFunction(bytes4 _functionSelector) public view returns (ExtensionMetadata memory) {
         ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-        return data.extensionMetadata[_functionSelector];
+        ExtensionMetadata memory metadata = data.extensionMetadata[_functionSelector];
+
+        bool isLocalExtension = metadata.implementation != address(0);
+
+        return isLocalExtension ? metadata : IDefaultExtensionSet(defaultExtensionSet).getExtensionForFunction(_functionSelector);
     }
 
     /// @dev Returns the extension implementation address stored in router, for the given function.

--- a/src/presets/example/RouterImmutable.sol
+++ b/src/presets/example/RouterImmutable.sol
@@ -3,15 +3,15 @@
 
 pragma solidity ^0.8.0;
 
-import "../BaseRouter.sol";
+import "../BaseRouterWithDefaults.sol";
 
 /**
  *  This smart contract is an EXAMPLE, and is not meant for use in production.
  */
 
-contract RouterImmutable is BaseRouter {
+contract RouterImmutable is BaseRouterWithDefaults {
     
-    constructor(Extension[] memory _extensions) BaseRouter(_extensions) {}
+    constructor(Extension[] memory _extensions) BaseRouterWithDefaults(_extensions) {}
 
     /*///////////////////////////////////////////////////////////////
                             Overrides

--- a/src/presets/example/RouterRegistryConstrained.sol
+++ b/src/presets/example/RouterRegistryConstrained.sol
@@ -3,7 +3,7 @@
 
 pragma solidity ^0.8.0;
 
-import "../BaseRouter.sol";
+import "../BaseRouterWithDefaults.sol";
 
 /**
  *  This smart contract is an EXAMPLE, and is not meant for use in production.
@@ -26,13 +26,13 @@ contract ExtensionRegistry {
 /**
  *  This smart contract is an EXAMPLE, and is not meant for use in production.
  */
-contract RouterRegistryConstrained is BaseRouter {
+contract RouterRegistryConstrained is BaseRouterWithDefaults {
 
     address public admin;
     ExtensionRegistry public registry;
 
     // @dev Cannot initialize with extensions before registry is set, so we pass empty array to base constructor.
-    constructor(address _registry) BaseRouter(new Extension[](0)) {
+    constructor(address _registry) BaseRouterWithDefaults(new Extension[](0)) {
         admin = msg.sender;
         registry = ExtensionRegistry(_registry);
     }

--- a/src/presets/example/RouterUpgradeable.sol
+++ b/src/presets/example/RouterUpgradeable.sol
@@ -12,7 +12,7 @@ contract RouterUpgradeable is BaseRouter {
     
     address public admin;
 
-    constructor(Extension[] memory _extensions) BaseRouter(_extensions) {
+    constructor() {
         admin = msg.sender;
     }
 

--- a/src/presets/utils/DefaultExtensionSet.sol
+++ b/src/presets/utils/DefaultExtensionSet.sol
@@ -43,23 +43,20 @@ contract DefaultExtensionSet is IDefaultExtensionSet, ExtensionState {
 
     /// @notice Returns all extensions stored.
     function getAllExtensions() external view returns (Extension[] memory allExtensions) {
-        ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-
-        string[] memory names = data.extensionNames.values();
+        string[] memory names = _extensionStateStorage().extensionNames.values();
         uint256 len = names.length;
 
         allExtensions = new Extension[](len);
 
         for (uint256 i = 0; i < len; i += 1) {
-            allExtensions[i] = data.extensions[names[i]];
+            allExtensions[i] = _extensionStateStorage().extensions[names[i]];
         }
     }
 
     /// @notice Returns the extension metadata and functions for a given extension.
     function getExtension(string memory _extensionName) public view returns (Extension memory) {
-        ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-        require(data.extensionNames.contains(_extensionName), "DefaultExtensionSet: extension does not exist.");
-        return data.extensions[_extensionName];
+        require(_extensionStateStorage().extensionNames.contains(_extensionName), "DefaultExtensionSet: extension does not exist.");
+        return _extensionStateStorage().extensions[_extensionName];
     }
 
     /// @notice Returns the extension's implementation smart contract address.
@@ -74,8 +71,7 @@ contract DefaultExtensionSet is IDefaultExtensionSet, ExtensionState {
 
     /// @notice Returns the extension metadata for a given function.
     function getExtensionForFunction(bytes4 _functionSelector) external view returns (ExtensionMetadata memory) {
-        ExtensionStateStorage.Data storage data = ExtensionStateStorage.extensionStateStorage();
-        ExtensionMetadata memory metadata = data.extensionMetadata[_functionSelector];
+        ExtensionMetadata memory metadata = _extensionStateStorage().extensionMetadata[_functionSelector];
         require(metadata.implementation != address(0), "DefaultExtensionSet: no extension for function.");
         return metadata;
     }


### PR DESCRIPTION
# Summary

### `Router` and `RouterPayable`
We split-up the current `core/Router` into two separate options `Router` and `RouterPayable`. All presets in the `/preset` directory use `Router`.

`Router` does not have a payable fallback function, or a `receive` function. This allows for a `receive` function to be added as an extension, in contracts built on top of `Router` or one of the base router presets. 

`RouterPayable` has a payable fallback function and a hardcoded `receive` function.

### `BaseRouter` and `BaseRouterWithDefaults`
We split-up the current `presets/BaseRouter` into two separate options `BaseRouter` and `BaseRouterWithDefaults`. 

`BaseRouter` no longer uses `DefaultExtensionSet` and is not meant to be initialized with default extensions in its constructor. 

`BaseRouterWithDefaults` on the other hand inherits `DefaultExtensionSet` and can be initialized with default extensions in its constructor.